### PR TITLE
Fixed hex values to strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,18 @@ clean:
 mod:
 	go mod init || true
 	go mod tidy
+
 test:
 	go test -p 1 ./...
+
+test-mac:
+	GOOS=darwin GOARCH=amd64 go test -p 1 ./...
+
 cover:
 	go test -p 1 --coverprofile=coverage.out ./...
 	go tool cover --html=coverage.out -o coverage.html
 	sh -c "open coverage.html || xdg-open coverage.html" 2>/dev/null
+
 fmt:
 	gofmt -l -w -s .
 

--- a/cluster/manager/config_test.go
+++ b/cluster/manager/config_test.go
@@ -21,7 +21,7 @@ import (
 	"devt.de/krotik/common/datautil"
 )
 
-const invalidFileName = "**" + string(0x0)
+const invalidFileName = "**" + "\x00"
 
 func TestDefaultStateInfo(t *testing.T) {
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,7 +9,7 @@ import (
 
 const testconf = "testconfig"
 
-const invalidFileName = "**" + string(0x0)
+const invalidFileName = "**" + "\x00"
 
 func TestConfig(t *testing.T) {
 

--- a/graph/globals.go
+++ b/graph/globals.go
@@ -108,7 +108,7 @@ const VERSION = 1
 /*
 MainDBEntryPrefix is the prefix for entries stored in the main database
 */
-const MainDBEntryPrefix = string(0x2)
+const MainDBEntryPrefix = "\x02"
 
 // MainDB entries
 // ==============
@@ -204,22 +204,22 @@ const StorageSuffixEdgesIndex = ".edgeidx"
 /*
 PrefixNSAttrs is the prefix for storing attributes of a node
 */
-const PrefixNSAttrs = string(0x01)
+const PrefixNSAttrs = "\x01"
 
 /*
 PrefixNSAttr is the prefix for storing the value of a node attribute
 */
-const PrefixNSAttr = string(0x02)
+const PrefixNSAttr = "\x02"
 
 /*
 PrefixNSSpecs is the prefix for storing specs of edges related to a node
 */
-const PrefixNSSpecs = string(0x03)
+const PrefixNSSpecs = "\x03"
 
 /*
 PrefixNSEdge is the prefix for storing a link from a node (and a spec) to an edge
 */
-const PrefixNSEdge = string(0x04)
+const PrefixNSEdge = "\x04"
 
 // Graph events
 //=============

--- a/graph/graphmanager_test.go
+++ b/graph/graphmanager_test.go
@@ -37,7 +37,7 @@ var DBDIRS = []string{GraphManagerTestDBDir1, GraphManagerTestDBDir2,
 	GraphManagerTestDBDir3, GraphManagerTestDBDir4, GraphManagerTestDBDir5,
 	GraphManagerTestDBDir6}
 
-const InvlaidFileName = "**" + string(0x0)
+const InvlaidFileName = "**" + "\x00"
 
 // Main function for all tests in this package
 

--- a/graph/graphstorage/diskgraphstorage_test.go
+++ b/graph/graphstorage/diskgraphstorage_test.go
@@ -27,7 +27,7 @@ const diskGraphStorageTestDBDir2 = "diskgraphstoragetest2"
 
 var dbdirs = []string{diskGraphStorageTestDBDir, diskGraphStorageTestDBDir2}
 
-const invalidFileName = "**" + string(0x0)
+const invalidFileName = "**" + "\x00"
 
 // Main function for all tests in this package
 

--- a/graph/util/indexmanager.go
+++ b/graph/util/indexmanager.go
@@ -39,12 +39,12 @@ var CaseSensitiveWordIndex = false
 /*
 PrefixAttrWord is the prefix used for word index entries
 */
-const PrefixAttrWord = string(0x01)
+const PrefixAttrWord = "\x01"
 
 /*
 PrefixAttrHash is the prefix used for hashes of attribute values
 */
-const PrefixAttrHash = string(0x02)
+const PrefixAttrHash = "\x01"
 
 /*
 IndexManager data structure

--- a/graph/util/namesmanager.go
+++ b/graph/util/namesmanager.go
@@ -15,27 +15,27 @@ import "encoding/binary"
 /*
 PrefixCode is the prefix for entries storing codes
 */
-const PrefixCode = string(0x0)
+const PrefixCode = "\x00"
 
 /*
 PrefixName is the prefix for entries storing names
 */
-const PrefixName = string(0x1)
+const PrefixName = "\x01"
 
 /*
 PrefixCounter is the prefix for counter entries
 */
-const PrefixCounter = string(0x0)
+const PrefixCounter = "\x00"
 
 /*
 Prefix16Bit is the prefix for 16 bit kind related entries
 */
-const Prefix16Bit = string(0x1)
+const Prefix16Bit = "\x01"
 
 /*
 Prefix32Bit is the prefix for attribute related entries
 */
-const Prefix32Bit = string(0x2)
+const Prefix32Bit = "\x02"
 
 /*
 NamesManager data structure

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -42,7 +42,7 @@ const RunLongRunningTests = true
 
 const testdb = "testdb"
 
-const invalidFileName = "**" + string(0x0)
+const invalidFileName = "**" + "\x00"
 
 var printLog = []string{}
 var errorLog = []string{}

--- a/storage/diskstoragemanager_test.go
+++ b/storage/diskstoragemanager_test.go
@@ -589,7 +589,7 @@ func TestDiskStorageManagerRollback(t *testing.T) {
 	}
 }
 
-const InvalidFileName = "**" + string(0x0)
+const InvalidFileName = "**" + "\x00"
 
 func TestDiskStorageManagerInit(t *testing.T) {
 	lockfile := lockutil.NewLockFile(DBDIR+"/"+"lock0.lck", time.Duration(50)*time.Millisecond)

--- a/storage/file/storagefile_test.go
+++ b/storage/file/storagefile_test.go
@@ -21,7 +21,7 @@ import (
 
 const DBDir = "storagefiletest"
 
-const InvalidFileName = "**" + string(0x0)
+const InvalidFileName = "**" + "\x00"
 
 func TestMain(m *testing.M) {
 	flag.Parse()

--- a/storage/paging/pagedstoragefile_test.go
+++ b/storage/paging/pagedstoragefile_test.go
@@ -23,7 +23,7 @@ import (
 
 const DBDIR = "pagingtest"
 
-const InvalidFileName = "**" + string(0x0)
+const InvalidFileName = "**" + "\x00"
 
 // Main function for all tests in this package
 


### PR DESCRIPTION
In order to compile in go 1.16.x we need to fix these conversion errors.