### PR TITLE
Fixes for running elisadb data-mining example on OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /build
 /eliasdb
 /examples/tutorial/run/
+/examples/game/run/
 /examples/chat/run/
 /examples/chat/res/chat/*.lock
 /examples/chat/res/chat/*-lock.json

--- a/examples/data-mining/docker-images/eliasdb/build.sh
+++ b/examples/data-mining/docker-images/eliasdb/build.sh
@@ -4,7 +4,7 @@ export ROOT_PATH=`pwd`
 
 # Build the collector component
 
-cp ../../../../eliasdb .
+env GOOS=linux GOARCH=amd64 go build ../../../../cli/eliasdb.go
 docker build --build-arg cluster_id=1 --tag data-mining/eliasdb1 .
 docker build --build-arg cluster_id=2 --tag data-mining/eliasdb2 .
 docker build --build-arg cluster_id=3 --tag data-mining/eliasdb3 .


### PR DESCRIPTION
Also includes a fix to the .gitignore so that the run directory for the game example is ignored.